### PR TITLE
Allow finding of `primary_key` names from model and fallback to 'id' …

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -318,7 +318,7 @@ class APIManager:
             max_page_size: int = 100,
             preprocessors=None,
             postprocessors=None,
-            primary_key: str = 'id',
+            primary_key: Optional[str] = None,
             serializer: Serializer = None,
             deserializer: Deserializer = None,
             includes=None,
@@ -542,6 +542,14 @@ class APIManager:
             for attr in additional_attributes:
                 if not hasattr(model, attr):
                     raise AttributeError(f'no attribute "{attr}" on model {model}')
+
+        # find the primary_key of the model or try and use 'id'
+        if primary_key is None:
+            pk_names = primary_key_names(model)
+            if len(pk_names) > 0:
+                primary_key = pk_names[0]
+            else:
+                primary_key = 'id'
 
         # Create a default serializer and deserializer if none have been
         # provided.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -346,10 +346,10 @@ class TestAPIManager(ManagerTestBase):
 
     def test_missing_id(self):
         """Tests that calling :meth:`APIManager.create_api` on a model without
-        an ``id`` column raises an exception if `primary_key` is not provided
+        an ``id`` column does not raise an exception if `primary_key` is not
+        provided
         """
-        with self.assertRaises(ValueError):
-            self.manager.create_api(self.Tag)
+        self.manager.create_api(self.Tag)
 
     def test_empty_collection_name(self):
         """Tests that calling :meth:`APIManager.create_api` with an empty


### PR DESCRIPTION
…if none are found

There was a regression that came in when setting the `primary_key` to `'id'` in `create_api_blueprint`