### PR TITLE
feat: added @> and <@ PostgreSQL operators

### DIFF
--- a/docs/fetching.rst
+++ b/docs/fetching.rst
@@ -798,8 +798,11 @@ appropriate `SQLAlchemy column operators`_.
 * ``has``
 * ``any``
 
-Flask-Restless also understands the `PostgreSQL network address operators`_
-``<<``, ``<<=``, ``>>``, ``>>=``, ``<>``, and ``&&``.
+Flask-Restless also understands:
+
+* `PostgreSQL network address operators`_ ``<<``, ``<<=``, ``>>``, ``>>=``, ``<>``, and ``&&``.
+* `PostgreSQL tsquery operators`_ ``to_tsquery`` and ``plainto_tsquery``.
+* `PostgreSQL array operators`_ ``<@`` and ``@>``.
 
 .. warning::
 

--- a/flask_restless/search.py
+++ b/flask_restless/search.py
@@ -138,6 +138,8 @@ OPERATORS = {
     'not_in': lambda f, a: ~f.in_(a),
     'to_tsquery': lambda f, a: f.match(a),
     'plainto_tsquery': lambda f, a: f.op('@@')(func.plainto_tsquery(a)),
+    '@>': lambda f, a, fn: f.op('@>')(a),
+    '<@': lambda f, a, fn: f.op('<@')(a),
     # Operators which accept three arguments.
     'has': lambda f, a, fn: f.has(_sub_operator(f, a, fn)),
     'any': lambda f, a, fn: f.any(_sub_operator(f, a, fn)),


### PR DESCRIPTION
I also added tests and documentation.

You can now search in PostgreSQL array type field:

`[{'name': 'tags', 'op': '@>', 'val': ['bug']}]`

This will search for all rows where the tags field contains the value 'bug'.